### PR TITLE
Rewrote modification for PHP 5

### DIFF
--- a/core/helper.php
+++ b/core/helper.php
@@ -61,7 +61,7 @@ class helper
 			$sql = "SELECT term_id FROM $table WHERE term = '$term1'";
 			$result = $this->db->sql_query($sql);
 			$row = $this->db->sql_fetchrow($result);
-			$code = $row['term_id'] ?? false;
+			$code = !empty($row['term_id']) ? $row['term_id'] : false;
 			$this->db->sql_freeresult($result);
 			if ($code)
 			{


### PR DESCRIPTION
The null coalescing operator (??) was introduced in PHP 7, while phpBB 3.2.9 allows PHP 5.4.7, so the modification was rewritten to account for that.